### PR TITLE
興味があったので、filterバージョンでの抽出に変更をしてみる

### DIFF
--- a/src/infrastructure/reservation/in_memory_reservation_repository.py
+++ b/src/infrastructure/reservation/in_memory_reservation_repository.py
@@ -16,8 +16,10 @@ class InMemoryReservationRepository(ReservationRepository):
     def find_available_reservations(self) -> List[Reservation]:
         now = datetime.datetime.now()
 
-        not_canceled_reservation = [r for r in self.data.values() if r.reservation_status == ReservationStatus.Reserved]
-        available_reservations = [r for r in not_canceled_reservation if r.time_range_to_reserve.start_datetime > now]
+        is_available_reservation = lambda x: x.reservation_status == ReservationStatus.Reserved \
+                                             and x.time_range_to_reserve.start_datetime > now
+
+        available_reservations = list(filter(is_available_reservation, self.data.values()))
 
         return available_reservations
 


### PR DESCRIPTION
自分が単純にリスト内包表記に慣れてなく、高階関数のほうがわかりやすいなぁと思い、Pythonで試しに書いてみる。
こっちのほうが良ければマージしてください

# メリット
  - reservation_statusが予約中 かつ、 time_range_to_reserve.start_datetime が今より未来である、という条件式が、より明示的になっている…と思う
# デメリット
  - リスト内包表記Ver.より2行増えている
    - やっぱり行数が少ないのは正義だと思えるし、そこまで複雑な条件式ではないので、そこまでメリットが大きくないように思える
- PEP 8の警告で is_available_reservation はlambdaではなくてdefで関数定義しろと言われてしまう
  - 素直にdefで関数定義してもいいが、生存期間が小さいし、それをやるくらいだったらリスト内包表記のほうが断然良い