### PR TITLE
仕様パターンを実装し「有効な予約」を取得する知識を、リポジトリから剥がした

### DIFF
--- a/src/domain/reservation/available_reservation_specification.py
+++ b/src/domain/reservation/available_reservation_specification.py
@@ -1,0 +1,18 @@
+import datetime
+from dataclasses import dataclass
+
+from src.domain.reservation.reservation import Reservation
+from src.domain.reservation.reservation_specification import ReservationSpecification
+from src.domain.reservation.reservation_status import ReservationStatus
+
+
+@dataclass
+class AvailableReservationSpecification(ReservationSpecification):
+    """
+    有効な予約仕様
+    """
+    now: datetime.datetime
+
+    def satisfying_elements_from(self, reservation: Reservation) -> bool:
+        return reservation.reservation_status == ReservationStatus.Reserved \
+               and reservation.time_range_to_reserve.start_datetime > self.now

--- a/src/domain/reservation/reservation_domain_service.py
+++ b/src/domain/reservation/reservation_domain_service.py
@@ -1,5 +1,7 @@
+import datetime
 from dataclasses import dataclass
 
+from src.domain.reservation.available_reservation_specification import AvailableReservationSpecification
 from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_repository import ReservationRepository
 
@@ -9,8 +11,11 @@ class ReservationDomainService:
     reservation_repository: ReservationRepository
 
     def can_not_reserve(self, reservation: Reservation) -> bool:
+        # Memo:　外から差し込むかと迷ったが、can_not_reserve は有効な予約を取得するということを明示したいので、
+        # あえてこの中で生成する
+        available_spec = AvailableReservationSpecification(datetime.datetime.now())
         # TODO: 性能面を考えると、クエリをカスタマイズしたほうがよさそう
-        available_reservations = self.reservation_repository.find_available_reservations()
+        available_reservations = self.reservation_repository.find_satisfying(available_spec)
 
         for not_canceled_reservation in available_reservations:
             if not_canceled_reservation.is_かぶり(reservation):

--- a/src/domain/reservation/reservation_repository.py
+++ b/src/domain/reservation/reservation_repository.py
@@ -16,11 +16,6 @@ class ReservationRepository(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def find_available_reservations(self) -> List[Reservation]:
-        pass
-
-
-    @abstractmethod
     def find_by_id(self, reservation_id: ReservationId) -> Union[Reservation, None]:
         pass
 

--- a/src/domain/reservation/reservation_repository.py
+++ b/src/domain/reservation/reservation_repository.py
@@ -3,6 +3,7 @@ from typing import List, Union
 
 from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_id import ReservationId
+from src.domain.reservation.reservation_specification import ReservationSpecification
 
 
 class ReservationRepository(metaclass=ABCMeta):
@@ -18,6 +19,7 @@ class ReservationRepository(metaclass=ABCMeta):
     def find_available_reservations(self) -> List[Reservation]:
         pass
 
+
     @abstractmethod
     def find_by_id(self, reservation_id: ReservationId) -> Union[Reservation, None]:
         pass
@@ -28,4 +30,8 @@ class ReservationRepository(metaclass=ABCMeta):
 
     @abstractmethod
     def change_time_range(self, reservation: Reservation) -> None:
+        pass
+
+    @abstractmethod
+    def find_satisfying(self, spec: ReservationSpecification) -> List[Reservation]:
         pass

--- a/src/domain/reservation/reservation_specification.py
+++ b/src/domain/reservation/reservation_specification.py
@@ -1,0 +1,13 @@
+from abc import ABCMeta, abstractmethod
+
+from src.domain.reservation.reservation import Reservation
+
+
+class ReservationSpecification(metaclass=ABCMeta):
+    """
+    予約仕様
+    """
+
+    @abstractmethod
+    def satisfying_elements_from(self, reservation: Reservation) -> bool:
+        pass

--- a/src/infrastructure/reservation/in_memory_reservation_repository.py
+++ b/src/infrastructure/reservation/in_memory_reservation_repository.py
@@ -1,11 +1,9 @@
-import datetime
 from typing import Dict, List, Union
 
 from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_id import ReservationId
 from src.domain.reservation.reservation_repository import ReservationRepository
 from src.domain.reservation.reservation_specification import ReservationSpecification
-from src.domain.reservation.reservation_status import ReservationStatus
 
 
 class InMemoryReservationRepository(ReservationRepository):
@@ -13,16 +11,6 @@ class InMemoryReservationRepository(ReservationRepository):
 
     def reserve_new_meeting_room(self, reservation: Reservation) -> None:
         self.data[reservation.id] = reservation
-
-    def find_available_reservations(self) -> List[Reservation]:
-        now = datetime.datetime.now()
-
-        is_available_reservation = lambda x: x.reservation_status == ReservationStatus.Reserved \
-                                             and x.time_range_to_reserve.start_datetime > now
-
-        available_reservations = list(filter(is_available_reservation, self.data.values()))
-
-        return available_reservations
 
     def find_satisfying(self, spec: ReservationSpecification) -> List[Reservation]:
         available_reservations = list(filter(spec.satisfying_elements_from, self.data.values()))

--- a/src/infrastructure/reservation/in_memory_reservation_repository.py
+++ b/src/infrastructure/reservation/in_memory_reservation_repository.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Union
 from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_id import ReservationId
 from src.domain.reservation.reservation_repository import ReservationRepository
+from src.domain.reservation.reservation_specification import ReservationSpecification
 from src.domain.reservation.reservation_status import ReservationStatus
 
 
@@ -20,6 +21,11 @@ class InMemoryReservationRepository(ReservationRepository):
                                              and x.time_range_to_reserve.start_datetime > now
 
         available_reservations = list(filter(is_available_reservation, self.data.values()))
+
+        return available_reservations
+
+    def find_satisfying(self, spec: ReservationSpecification) -> List[Reservation]:
+        available_reservations = list(filter(spec.satisfying_elements_from, self.data.values()))
 
         return available_reservations
 

--- a/src/infrastructure/reservation/orator/orator_reservation_repository.py
+++ b/src/infrastructure/reservation/orator/orator_reservation_repository.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import datetime
 from dataclasses import dataclass
 from typing import Union, List
 
@@ -10,7 +9,6 @@ from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_id import ReservationId
 from src.domain.reservation.reservation_repository import ReservationRepository
 from src.domain.reservation.reservation_specification import ReservationSpecification
-from src.domain.reservation.reservation_status import ReservationStatus
 from src.infrastructure.reservation.orator.orator_reservation_model import OratorReservationModel
 
 
@@ -30,15 +28,6 @@ class OratorReservationRepository(ReservationRepository):
         orator_reservation = OratorReservationModel.to_orator_model(reservation)
 
         OratorReservationModel.update(orator_reservation, reservation_status=reservation.reservation_status.value)
-
-    def find_available_reservations(self) -> List[Reservation]:
-        now = datetime.datetime.now()
-
-        reservations = self.database_manager.table('reservation') \
-            .where('reservation_status', ReservationStatus.Reserved.value) \
-            .where('start_datetime', '>', now).get()
-
-        return [OratorReservationModel.to_reservation(r) for r in reservations]
 
     def find_satisfying(self, spec: ReservationSpecification) -> List[Reservation]:
         return list(filter(spec.satisfying_elements_from, OratorReservationModel.all()))

--- a/src/infrastructure/reservation/orator/orator_reservation_repository.py
+++ b/src/infrastructure/reservation/orator/orator_reservation_repository.py
@@ -9,6 +9,7 @@ from orator import DatabaseManager, Model
 from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_id import ReservationId
 from src.domain.reservation.reservation_repository import ReservationRepository
+from src.domain.reservation.reservation_specification import ReservationSpecification
 from src.domain.reservation.reservation_status import ReservationStatus
 from src.infrastructure.reservation.orator.orator_reservation_model import OratorReservationModel
 
@@ -38,6 +39,9 @@ class OratorReservationRepository(ReservationRepository):
             .where('start_datetime', '>', now).get()
 
         return [OratorReservationModel.to_reservation(r) for r in reservations]
+
+    def find_satisfying(self, spec: ReservationSpecification) -> List[Reservation]:
+        return list(filter(spec.satisfying_elements_from, OratorReservationModel.all()))
 
     def find_by_id(self, reservation_id: ReservationId) -> Union[Reservation, None]:
         orator_reservation = OratorReservationModel.find(reservation_id.value)

--- a/tests/infrastructure/test_reservation_repository.py
+++ b/tests/infrastructure/test_reservation_repository.py
@@ -1,0 +1,60 @@
+import dataclasses
+import datetime
+import uuid
+
+import freezegun
+import pytest
+
+from src.domain.employee.employee_id import EmployeeId
+from src.domain.meeting_room.meeting_room_id import MeetingRoomId
+from src.domain.reservation.available_reservation_specification import AvailableReservationSpecification
+from src.domain.reservation.number_of_participants import NumberOfParticipants
+from src.domain.reservation.reservation import Reservation
+from src.domain.reservation.reservation_id import ReservationId
+from src.domain.reservation.reservation_status import ReservationStatus
+from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
+from src.domain.reservation.使用日時 import 使用日時
+from src.infrastructure.reservation.in_memory_reservation_repository import InMemoryReservationRepository
+
+
+class TestReservationRepository:
+
+    @pytest.fixture
+    @freezegun.freeze_time('2020-4-1 10:00')
+    def reservation_0401(self) -> Reservation:
+        """不正でないReservationインスタンスを作成するだけのfixture"""
+        return Reservation(ReservationId(str(uuid.uuid4())),
+                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
+                           NumberOfParticipants(4),
+                           MeetingRoomId(str(uuid.uuid4())),
+                           EmployeeId(str(uuid.uuid4())))
+
+    @pytest.fixture
+    @freezegun.freeze_time('2020-3-1 10:00')
+    def reservation_0301(self) -> Reservation:
+        """不正でないReservationインスタンスを作成するだけのfixture"""
+        return Reservation(ReservationId(str(uuid.uuid4())),
+                           TimeRangeToReserve(使用日時(2020, 3, 2, 13, 00), 使用日時(2020, 3, 2, 14, 00)),
+                           NumberOfParticipants(4),
+                           MeetingRoomId(str(uuid.uuid4())),
+                           EmployeeId(str(uuid.uuid4())))
+
+    @freezegun.freeze_time('2020-4-1 10:00')
+    def test_find_available_reservations(self, reservation_0401, reservation_0301):
+        repository = InMemoryReservationRepository()
+
+        invalid_reservation = dataclasses.replace(reservation_0401, id=ReservationId(str(uuid.uuid4())),
+                                                  reservation_status=ReservationStatus.Canceled)
+
+        repository.data[reservation_0401.id] = reservation_0401
+        repository.data[reservation_0301.id] = reservation_0301
+        repository.data[invalid_reservation.id] = invalid_reservation
+
+        expected = [reservation_0401]
+
+        # TODO:ここに時間を入れるのは、どうかは、あとで考える
+        spec = AvailableReservationSpecification(datetime.datetime.now())
+
+        # 仕様を満たしたものをSelectしてくる
+        actual = repository.find_satisfying(spec)
+        assert expected == actual


### PR DESCRIPTION
仕様パターンを使って、リポジトリの内部から、「有効な予約」を取得する知識を剥がしてみたPR

# 懸念点
- ReserveDomainService 内で AvailableReservationSpecification を生成している
  - 今までの生成の知識と利用の知識を混ぜるなという方針に反しているように見える
- あと、datetime.now() 問題がまた浮上している感

# AvailableReservationSpecification DomainService内で生成している言い訳
- ReserveDomainService.can_not_reserve メソッドは、「有効な予約」を取得することを期待している
  - そのために、 find_available_reservation メソッド名として明示していた
- それを find_satisfying という仕様を満たした予約を取得するという、汎用的な名前にしている
  - なので、「有効な予約を取得する仕様」として AvailableReservationSpecification を内部で作って明示するようにしたい