### PR TITLE
テスト用Reservationを生成担当する `DummyReservationBuilder` の導入

### DIFF
--- a/tests/domain/reservation/dummy_reservation_builder.py
+++ b/tests/domain/reservation/dummy_reservation_builder.py
@@ -37,13 +37,17 @@ class DummyReservationBuilder:
     __dummy_reservation: Reservation = dataclasses.field(init=False)
 
     def __post_init__(self):
-        time_range_to_reserve = self._make_tomorrow_time_to_range()
-
-        self.__dummy_reservation = Reservation(ReservationId('dummy_reservation_id'),
-                                               time_range_to_reserve,
+        self.__dummy_reservation = Reservation(self._default_reservation_id(),
+                                               self._make_tomorrow_time_to_range(),
                                                NumberOfParticipants(4),
                                                MeetingRoomId('A'),
                                                EmployeeId('001'))
+
+    def _default_reservation_id(self) -> ReservationId:
+        # これを採用したメリット: Reservationインスタンスのassertionが楽にできる
+        # これを採用したリスク: インスタンスを複数つくれば、ReservationIdかぶりをつくれる
+
+        return ReservationId('dummy_reservation_id')
 
     def _make_tomorrow_time_to_range(self) -> TimeRangeToReserve:
         tomorrow = self.now + datetime.timedelta(days=1)

--- a/tests/domain/reservation/dummy_reservation_builder.py
+++ b/tests/domain/reservation/dummy_reservation_builder.py
@@ -78,7 +78,7 @@ class DummyReservationBuilder:
     def with_random_id(self) -> DummyReservationBuilder:
         # テストデータ作成のための強引なミューテーションだから妥協して使用している
         # ReservationId の生成ルールがガードできていないので注意！
-        object.__setattr__(self.dummy_reservation, 'id', ReservationId(str(uuid.uuid4())))
+        self.dummy_reservation = dataclasses.replace(self.dummy_reservation, id=ReservationId(str(uuid.uuid4())))
 
         return self
 

--- a/tests/domain/reservation/dummy_reservation_builder.py
+++ b/tests/domain/reservation/dummy_reservation_builder.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import uuid
+from dataclasses import dataclass
+from typing import Set
+
+from src.domain.employee.employee_id import EmployeeId
+from src.domain.meeting_room.meeting_room_id import MeetingRoomId
+from src.domain.reservation.number_of_participants import NumberOfParticipants
+from src.domain.reservation.reservation import Reservation
+from src.domain.reservation.reservation_id import ReservationId
+from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
+from src.domain.reservation.使用日時 import 使用日時
+
+
+@dataclass
+class DummyReservationBuilder:
+    """
+    発想: あくまで単体のReservationをつくるのを楽にするクラス
+
+    生成するReservationIdの重複は防いでいる
+
+
+    ReservationId以外の属性や、Reservation間の不正は検知はできない
+        - 会議室や、予約時間帯の被っている不正なデータをつくれてしまう
+        - 存在しない会議室IDや存在しない予約者IDもつくれる
+        - やろうと思えば、生成したReservationをrepositoryに登録して、ドメインサービスを適用するってことはできるが、やりすぎでは？
+
+    過去の日時を持つデータはつくれない
+        - 結局、使用日時クラスのnow で判断しているため
+        - with_time_range_to_reserve を使って差し込もうな
+    """
+    now: datetime.datetime
+    used_reservation_ids: Set[Reservation] = dataclasses.field(default_factory=set)
+
+    def __post_init__(self):
+        time_range_to_reserve = self._make_tomorrow_time_to_range()
+
+        self.dummy_reservation = Reservation(ReservationId('dummy_reservation_id'),
+                                             time_range_to_reserve,
+                                             NumberOfParticipants(4),
+                                             MeetingRoomId('A'),
+                                             EmployeeId('001'))
+
+    def _make_tomorrow_time_to_range(self) -> TimeRangeToReserve:
+        tomorrow = self.now + datetime.timedelta(days=1)
+
+        yyyy, mm, dd, *_ = tomorrow.timetuple()
+
+        return TimeRangeToReserve(使用日時(yyyy, mm, dd, 13, 00),
+                                  使用日時(yyyy, mm, dd, 14, 00))
+
+    def with_meeting_room_id(self, meeting_room_id: MeetingRoomId) -> DummyReservationBuilder:
+        # テストデータ作成のための強引なミューテーション
+        object.__setattr__(self.dummy_reservation, 'meeting_room_id', meeting_room_id)
+
+        return self
+
+    def with_cancel(self) -> DummyReservationBuilder:
+        self.dummy_reservation = self.dummy_reservation.cancel()
+
+        return self
+
+    def with_reserver_id(self, reserver_id: EmployeeId) -> DummyReservationBuilder:
+        # テストデータ作成のための強引なミューテーションだから妥協して使用している
+        object.__setattr__(self.dummy_reservation, 'reserver_id', reserver_id)
+
+        return self
+
+    def with_time_range_to_reserve(self, time_range_to_reserve: TimeRangeToReserve) -> DummyReservationBuilder:
+        # テストデータ作成のための強引なミューテーションだから妥協して使用している
+        object.__setattr__(self.dummy_reservation, 'time_range_to_reserve', time_range_to_reserve)
+
+        return self
+
+    def with_random_id(self) -> DummyReservationBuilder:
+        # テストデータ作成のための強引なミューテーションだから妥協して使用している
+        # ReservationId の生成ルールがガードできていないので注意！
+        object.__setattr__(self.dummy_reservation, 'id', ReservationId(str(uuid.uuid4())))
+
+        return self
+
+    def build(self) -> Reservation:
+        if self._has_already_build_reservation_id():
+            self.with_random_id()
+
+        self.used_reservation_ids.add(self.dummy_reservation.id)
+
+        return self.dummy_reservation
+
+    def _has_already_build_reservation_id(self) -> bool:
+        return self.dummy_reservation.id in self.used_reservation_ids

--- a/tests/domain/reservation/dummy_reservation_builder.py
+++ b/tests/domain/reservation/dummy_reservation_builder.py
@@ -34,15 +34,16 @@ class DummyReservationBuilder:
     """
     now: datetime.datetime
     used_reservation_ids: Set[Reservation] = dataclasses.field(default_factory=set)
+    __dummy_reservation: Reservation = dataclasses.field(init=False)
 
     def __post_init__(self):
         time_range_to_reserve = self._make_tomorrow_time_to_range()
 
-        self.dummy_reservation = Reservation(ReservationId('dummy_reservation_id'),
-                                             time_range_to_reserve,
-                                             NumberOfParticipants(4),
-                                             MeetingRoomId('A'),
-                                             EmployeeId('001'))
+        self.__dummy_reservation = Reservation(ReservationId('dummy_reservation_id'),
+                                               time_range_to_reserve,
+                                               NumberOfParticipants(4),
+                                               MeetingRoomId('A'),
+                                               EmployeeId('001'))
 
     def _make_tomorrow_time_to_range(self) -> TimeRangeToReserve:
         tomorrow = self.now + datetime.timedelta(days=1)
@@ -54,31 +55,32 @@ class DummyReservationBuilder:
 
     def with_meeting_room_id(self, meeting_room_id: MeetingRoomId) -> DummyReservationBuilder:
         # テストデータ作成のための強引なミューテーション
-        object.__setattr__(self.dummy_reservation, 'meeting_room_id', meeting_room_id)
+        self.__dummy_reservation = dataclasses.replace(self.__dummy_reservation, meeting_room_id=meeting_room_id)
 
         return self
 
     def with_cancel(self) -> DummyReservationBuilder:
-        self.dummy_reservation = self.dummy_reservation.cancel()
+        self.__dummy_reservation = self.__dummy_reservation.cancel()
 
         return self
 
     def with_reserver_id(self, reserver_id: EmployeeId) -> DummyReservationBuilder:
         # テストデータ作成のための強引なミューテーションだから妥協して使用している
-        object.__setattr__(self.dummy_reservation, 'reserver_id', reserver_id)
+        self.__dummy_reservation = dataclasses.replace(self.__dummy_reservation, reserver_id=reserver_id)
 
         return self
 
     def with_time_range_to_reserve(self, time_range_to_reserve: TimeRangeToReserve) -> DummyReservationBuilder:
         # テストデータ作成のための強引なミューテーションだから妥協して使用している
-        object.__setattr__(self.dummy_reservation, 'time_range_to_reserve', time_range_to_reserve)
+        self.__dummy_reservation = dataclasses.replace(self.__dummy_reservation,
+                                                       time_range_to_reserve=time_range_to_reserve)
 
         return self
 
     def with_random_id(self) -> DummyReservationBuilder:
         # テストデータ作成のための強引なミューテーションだから妥協して使用している
         # ReservationId の生成ルールがガードできていないので注意！
-        self.dummy_reservation = dataclasses.replace(self.dummy_reservation, id=ReservationId(str(uuid.uuid4())))
+        self.__dummy_reservation = dataclasses.replace(self.__dummy_reservation, id=ReservationId(str(uuid.uuid4())))
 
         return self
 
@@ -86,9 +88,9 @@ class DummyReservationBuilder:
         if self._has_already_build_reservation_id():
             self.with_random_id()
 
-        self.used_reservation_ids.add(self.dummy_reservation.id)
+        self.used_reservation_ids.add(self.__dummy_reservation.id)
 
-        return self.dummy_reservation
+        return self.__dummy_reservation
 
     def _has_already_build_reservation_id(self) -> bool:
-        return self.dummy_reservation.id in self.used_reservation_ids
+        return self.__dummy_reservation.id in self.used_reservation_ids

--- a/tests/domain/reservation/dummy_reservation_builder.py
+++ b/tests/domain/reservation/dummy_reservation_builder.py
@@ -49,17 +49,21 @@ class DummyReservationBuilder:
         if self.execute_date is None:
             self.execute_date = datetime.datetime.today()
 
-        self.__dummy_reservation = Reservation(self._default_reservation_id(),
+        self.__dummy_reservation = Reservation(self._get_next_reservation_id(),
                                                self._default_time_to_range(),
                                                NumberOfParticipants(4),
                                                MeetingRoomId('A'),
                                                EmployeeId('001'))
 
-    def _default_reservation_id(self) -> ReservationId:
+    def _get_next_reservation_id(self) -> ReservationId:
+        """次のReservationIdを生成する。Idの値は1から順にインクリメントする。"""
         # これを採用したメリット: Reservationインスタンスのassertionが楽にできる
         # これを採用したリスク: インスタンスを複数つくれば、ReservationIdかぶりをつくれる
 
-        return ReservationId('dummy_reservation_id')
+        used_id_count = len(self.used_reservation_ids)
+        next_id = str(used_id_count + 1)
+
+        return ReservationId(next_id)
 
     def _default_time_to_range(self) -> TimeRangeToReserve:
         """実行日の翌日13時〜14時 がデフォルトの予約時間帯"""
@@ -102,11 +106,17 @@ class DummyReservationBuilder:
 
     def build(self) -> Reservation:
         if self._has_already_build_reservation_id():
-            self.with_random_id()
+            self._set_next_id()
 
-        self.used_reservation_ids.add(self.__dummy_reservation.id)
+        self._register_used_id()
 
         return self.__dummy_reservation
 
     def _has_already_build_reservation_id(self) -> bool:
         return self.__dummy_reservation.id in self.used_reservation_ids
+
+    def _set_next_id(self) -> None:
+        self.__dummy_reservation = dataclasses.replace(self.__dummy_reservation, id=self._get_next_reservation_id())
+
+    def _register_used_id(self) -> None:
+        self.used_reservation_ids.add(self.__dummy_reservation.id)

--- a/tests/domain/reservation/test_dummy_reservation_builder.py
+++ b/tests/domain/reservation/test_dummy_reservation_builder.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime
+
+import freezegun
+import pytest
+
+from src.domain.employee.employee_id import EmployeeId
+from src.domain.meeting_room.meeting_room_id import MeetingRoomId
+from src.domain.reservation.number_of_participants import NumberOfParticipants
+from src.domain.reservation.reservation import Reservation
+from src.domain.reservation.reservation_id import ReservationId
+from src.domain.reservation.reservation_status import ReservationStatus
+from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
+from src.domain.reservation.使用日時 import 使用日時
+from tests.domain.reservation.dummy_reservation_builder import DummyReservationBuilder
+
+
+class TestDummyReservationBuilder:
+    @pytest.fixture
+    @freezegun.freeze_time('2020-4-1 10:00')
+    def default_dummy_reservation(self) -> Reservation:
+        return Reservation(ReservationId('dummy_reservation_id'),
+                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
+                           NumberOfParticipants(4),
+                           MeetingRoomId('A'),
+                           EmployeeId('001'))
+
+    @freezegun.freeze_time('2020-4-1 10:00')
+    def test_特に何も指定しないとただの翌日のReservationがつくれる(self, default_dummy_reservation: Reservation):
+        builder = DummyReservationBuilder(datetime.datetime.now())
+
+        assert isinstance(builder.build(), Reservation)
+
+    def test_IDはつくるたびに必ず変わる(self):
+        # 逆に言うとおなじIDをもつreservationは生成されない
+        builder = DummyReservationBuilder(datetime.datetime.now())
+
+        assert builder.build().id != builder.build().id
+
+    @freezegun.freeze_time('2020-4-1 10:00')
+    def test_キャンセル済みのReservationがつくれる(self, default_dummy_reservation: Reservation):
+        builder = DummyReservationBuilder(datetime.datetime.now())
+
+        expected = dataclasses.replace(default_dummy_reservation, reservation_status=ReservationStatus.Canceled)
+
+        assert builder.with_cancel().build() == expected
+
+    @freezegun.freeze_time('2020-4-1 10:00')
+    def test_会議室IDを指定できる(self, default_dummy_reservation: Reservation):
+        builder = DummyReservationBuilder(datetime.datetime.now())
+
+        another_meeting_room_id = MeetingRoomId('Z')
+
+        expected = dataclasses.replace(default_dummy_reservation, meeting_room_id=another_meeting_room_id)
+
+        assert builder.with_meeting_room_id(another_meeting_room_id).build() == expected
+
+    @freezegun.freeze_time('2020-4-1 10:00')
+    def test_予約者IDを指定できる(self, default_dummy_reservation: Reservation):
+        builder = DummyReservationBuilder(datetime.datetime.now())
+
+        another_reserver_id = EmployeeId('999')
+
+        expected = dataclasses.replace(default_dummy_reservation, reserver_id=another_reserver_id)
+
+        assert builder.with_reserver_id(another_reserver_id).build() == expected
+
+    @freezegun.freeze_time('2020-12-31 10:00')
+    def test_予約時間帯を指定できる(self, default_dummy_reservation: Reservation):
+        builder = DummyReservationBuilder(datetime.datetime(2020, 12, 31, 10, 00))
+
+        another_time_range_to_reserve = TimeRangeToReserve(使用日時(2020, 12, 31, 13, 00),
+                                                           使用日時(2020, 12, 31, 14, 00))
+
+        expected = dataclasses.replace(default_dummy_reservation, time_range_to_reserve=another_time_range_to_reserve)
+
+        assert builder.with_time_range_to_reserve(another_time_range_to_reserve).build() == expected

--- a/tests/domain/reservation/test_dummy_reservation_builder.py
+++ b/tests/domain/reservation/test_dummy_reservation_builder.py
@@ -45,7 +45,7 @@ class TestDummyReservationBuilder:
         assert reservation_id_1 == reservation_id_2
 
     @freezegun.freeze_time('2020-4-1 10:00')
-    def test_複雑なReservationもメソッドチェーンでつくりやすいよ(self, default_dummy_reservation: Reservation):
+    def test_複雑なReservationもメソッドチェーンでつくりやすいよ(self):
         another_time_range_to_reserve = TimeRangeToReserve(使用日時(2020, 4, 15, 13, 00), 使用日時(2020, 4, 15, 14, 00))
         another_meeting_room_id = MeetingRoomId('Z')
         another_employee_id_999 = EmployeeId('999')

--- a/tests/domain/reservation/test_dummy_reservation_builder.py
+++ b/tests/domain/reservation/test_dummy_reservation_builder.py
@@ -1,4 +1,3 @@
-import dataclasses
 import datetime
 
 import freezegun
@@ -67,42 +66,3 @@ class TestDummyReservationBuilder:
             .build()
 
         assert actual == expected
-
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def test_キャンセル済みのReservationがつくれる(self, default_dummy_reservation: Reservation):
-        builder = DummyReservationBuilder(datetime.datetime.now())
-
-        expected = dataclasses.replace(default_dummy_reservation, reservation_status=ReservationStatus.Canceled)
-
-        assert builder.with_cancel().build() == expected
-
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def test_会議室IDを指定できる(self, default_dummy_reservation: Reservation):
-        builder = DummyReservationBuilder(datetime.datetime.now())
-
-        another_meeting_room_id = MeetingRoomId('Z')
-
-        expected = dataclasses.replace(default_dummy_reservation, meeting_room_id=another_meeting_room_id)
-
-        assert builder.with_meeting_room_id(another_meeting_room_id).build() == expected
-
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def test_予約者IDを指定できる(self, default_dummy_reservation: Reservation):
-        builder = DummyReservationBuilder(datetime.datetime.now())
-
-        another_reserver_id = EmployeeId('999')
-
-        expected = dataclasses.replace(default_dummy_reservation, reserver_id=another_reserver_id)
-
-        assert builder.with_reserver_id(another_reserver_id).build() == expected
-
-    @freezegun.freeze_time('2020-12-31 10:00')
-    def test_予約時間帯を指定できる(self, default_dummy_reservation: Reservation):
-        builder = DummyReservationBuilder(datetime.datetime(2020, 12, 31, 10, 00))
-
-        another_time_range_to_reserve = TimeRangeToReserve(使用日時(2020, 12, 31, 13, 00),
-                                                           使用日時(2020, 12, 31, 14, 00))
-
-        expected = dataclasses.replace(default_dummy_reservation, time_range_to_reserve=another_time_range_to_reserve)
-
-        assert builder.with_time_range_to_reserve(another_time_range_to_reserve).build() == expected

--- a/tests/domain/reservation/test_dummy_reservation_builder.py
+++ b/tests/domain/reservation/test_dummy_reservation_builder.py
@@ -1,5 +1,3 @@
-import datetime
-
 import freezegun
 import pytest
 
@@ -24,14 +22,15 @@ class TestDummyReservationBuilder:
                            MeetingRoomId('A'),
                            EmployeeId('001'))
 
-    def test_単一の正常なReservationを生成できる(self, default_dummy_reservation: Reservation):
-        builder = DummyReservationBuilder(datetime.datetime.now())
+    @freezegun.freeze_time('2020-4-1 10:00')
+    def test_単一の正常なReservationを生成できる_予約時間帯は翌日13時から14時がデフォルトとなる(self, default_dummy_reservation: Reservation):
+        builder = DummyReservationBuilder()
 
         assert builder.build() == default_dummy_reservation
 
     def test_同一インスタンスから生成されたReservationのIDは重複しない(self):
         # 言い換えると、生成のたびにReservationIdは変化する
-        builder = DummyReservationBuilder(datetime.datetime.now())
+        builder = DummyReservationBuilder()
 
         id1 = builder.build().id
         id2 = builder.build().id
@@ -40,8 +39,8 @@ class TestDummyReservationBuilder:
         assert len({id1, id2, id3}) == 3
 
     def test_別のインスタンスであれば同一IDを持つReservationがつくれてしまう(self):
-        reservation_id_1 = DummyReservationBuilder(datetime.datetime.now()).build().id
-        reservation_id_2 = DummyReservationBuilder(datetime.datetime.now()).build().id
+        reservation_id_1 = DummyReservationBuilder().build().id
+        reservation_id_2 = DummyReservationBuilder().build().id
 
         assert reservation_id_1 == reservation_id_2
 
@@ -58,7 +57,7 @@ class TestDummyReservationBuilder:
                                another_employee_id_999,
                                ReservationStatus.Canceled)
 
-        actual = DummyReservationBuilder(datetime.datetime.now()) \
+        actual = DummyReservationBuilder() \
             .with_time_range_to_reserve(another_time_range_to_reserve) \
             .with_meeting_room_id(another_meeting_room_id) \
             .with_reserver_id(another_employee_id_999) \

--- a/tests/domain/reservation/test_dummy_reservation_builder.py
+++ b/tests/domain/reservation/test_dummy_reservation_builder.py
@@ -33,11 +33,15 @@ class TestDummyReservationBuilder:
 
         assert isinstance(builder.build(), Reservation)
 
-    def test_IDはつくるたびに必ず変わる(self):
+    def test_生成された各ReservationのIDはつくるたびに必ず変わる(self):
         # 逆に言うとおなじIDをもつreservationは生成されない
         builder = DummyReservationBuilder(datetime.datetime.now())
 
-        assert builder.build().id != builder.build().id
+        id1 = builder.build().id
+        id2 = builder.build().id
+        id3 = builder.build().id
+
+        assert len({id1, id2, id3}) == 3
 
     @freezegun.freeze_time('2020-4-1 10:00')
     def test_キャンセル済みのReservationがつくれる(self, default_dummy_reservation: Reservation):

--- a/tests/domain/reservation/test_dummy_reservation_builder.py
+++ b/tests/domain/reservation/test_dummy_reservation_builder.py
@@ -36,11 +36,9 @@ class TestDummyReservationBuilder:
         # 1つのテストで複数のBuilderインスタンスを利用するときのId衝突を防ぐときに役立つ機能
         builder = DummyReservationBuilder()
 
-        random_id1 = builder.with_random_id().build().id
-        random_id2 = builder.with_random_id().build().id
-        random_id3 = builder.with_random_id().build().id
+        random_id = builder.with_random_id().build().id
 
-        assert [random_id1, random_id2, random_id3] != [ReservationId('1'), ReservationId('2'), ReservationId('3')]
+        assert random_id != ReservationId('1')
 
     def test_別のインスタンスであれば同一IDを持つReservationがつくれてしまう(self):
         reservation_id_1 = DummyReservationBuilder().build().id

--- a/tests/domain/reservation/test_reservations.py
+++ b/tests/domain/reservation/test_reservations.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytest
 
 from src.domain.reservation.available_reservations import AvailableReservations
@@ -11,7 +9,7 @@ from tests.domain.reservation.dummy_reservation_builder import DummyReservationB
 class TestReservations:
     @pytest.fixture
     def canceled_reservation(self) -> Reservation:
-        return DummyReservationBuilder(datetime.datetime.now()).with_cancel().build()
+        return DummyReservationBuilder().with_cancel().build()
 
     def test_初期化時に有効ではない予約を含むリストを渡すとエラーとなる(self, canceled_reservation):
         with pytest.raises(NotAvailableReservationError):

--- a/tests/domain/reservation/test_reservations.py
+++ b/tests/domain/reservation/test_reservations.py
@@ -1,37 +1,22 @@
-import uuid
+import datetime
 
-import freezegun
 import pytest
 
-from src.domain.employee.employee_id import EmployeeId
-from src.domain.meeting_room.meeting_room_id import MeetingRoomId
 from src.domain.reservation.available_reservations import AvailableReservations
 from src.domain.reservation.errors import NotAvailableReservationError
-from src.domain.reservation.number_of_participants import NumberOfParticipants
 from src.domain.reservation.reservation import Reservation
-from src.domain.reservation.reservation_id import ReservationId
-from src.domain.reservation.reservation_status import ReservationStatus
-from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
-from src.domain.reservation.使用日時 import 使用日時
+from tests.domain.reservation.dummy_reservation_builder import DummyReservationBuilder
 
 
-class TestReservationsTest:
+class TestReservations:
     @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
     def canceled_reservation(self) -> Reservation:
-        return Reservation(ReservationId(str(uuid.uuid4())),
-                           TimeRangeToReserve(使用日時(2020, 4, 3, 13, 00), 使用日時(2020, 4, 3, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'),
-                           ReservationStatus.Canceled)
+        return DummyReservationBuilder(datetime.datetime.now()).with_cancel().build()
 
-    @freezegun.freeze_time('2020-4-1 10:00')
     def test_初期化時に有効ではない予約を含むリストを渡すとエラーとなる(self, canceled_reservation):
         with pytest.raises(NotAvailableReservationError):
             AvailableReservations([canceled_reservation])
 
-    @freezegun.freeze_time('2020-4-1 10:00')
     def test_有効ではない予約を追加時にエラーとなる(self, canceled_reservation):
         with pytest.raises(NotAvailableReservationError):
             AvailableReservations().add(canceled_reservation)

--- a/tests/usecase/reservation/in_memory/test_in_memory_cancel_meeting_room_usecase.py
+++ b/tests/usecase/reservation/in_memory/test_in_memory_cancel_meeting_room_usecase.py
@@ -1,39 +1,26 @@
 import dataclasses
-import uuid
+import datetime
 
-import freezegun
 import pytest
 
-from src.domain.employee.employee_id import EmployeeId
-from src.domain.meeting_room.meeting_room_id import MeetingRoomId
-from src.domain.reservation.number_of_participants import NumberOfParticipants
 from src.domain.reservation.reservation import Reservation
-from src.domain.reservation.reservation_id import ReservationId
 from src.domain.reservation.reservation_status import ReservationStatus
-from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
-from src.domain.reservation.使用日時 import 使用日時
 from src.infrastructure.reservation.in_memory_reservation_repository import InMemoryReservationRepository
 from src.usecase.reservation.cancel_meeting_room_usecase import CancelMeetingRoomUsecase
 from src.usecase.reservation.errors import NotFoundReservationError
+from tests.domain.reservation.dummy_reservation_builder import DummyReservationBuilder
 
 
-@freezegun.freeze_time('2020-4-1 10:00')
 class TestInMemoryCancelMeetingRoomUsecase:
     def setup(self):
         self.reservation_repository = InMemoryReservationRepository()
         self.usecase = CancelMeetingRoomUsecase(self.reservation_repository)
 
     @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
     def reservation(self) -> Reservation:
-        """不正でないReservationインスタンスを作成するだけのfixture"""
-        return Reservation(ReservationId(str(uuid.uuid4())),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'))
+        return DummyReservationBuilder(datetime.datetime.now()).build()
 
-    def test_予約をキャンセルができること(self, reservation):
+    def test_予約をキャンセルができること(self, reservation: Reservation):
         expected = dataclasses.replace(reservation, reservation_status=ReservationStatus.Canceled)
 
         self.reservation_repository.data[reservation.id] = reservation
@@ -42,11 +29,11 @@ class TestInMemoryCancelMeetingRoomUsecase:
 
         assert expected == self.reservation_repository.data[reservation.id]
 
-    def test_存在しない予約に対してキャンセルするのはダメだよ(self, reservation):
+    def test_存在しない予約に対してキャンセルするのはダメだよ(self, reservation: Reservation):
         with pytest.raises(NotFoundReservationError):
             self.usecase.cancel_meeting_room(reservation.id)
 
-    def test_キャンセル済みに対してキャンセルするのもダメだよ(self, reservation):
+    def test_キャンセル済みに対してキャンセルするのもダメだよ(self, reservation: Reservation):
         canceled_reservation = dataclasses.replace(reservation, reservation_status=ReservationStatus.Canceled)
 
         self.reservation_repository.data[canceled_reservation.id] = canceled_reservation

--- a/tests/usecase/reservation/in_memory/test_in_memory_cancel_meeting_room_usecase.py
+++ b/tests/usecase/reservation/in_memory/test_in_memory_cancel_meeting_room_usecase.py
@@ -1,5 +1,4 @@
 import dataclasses
-import datetime
 
 import pytest
 
@@ -18,7 +17,7 @@ class TestInMemoryCancelMeetingRoomUsecase:
 
     @pytest.fixture
     def reservation(self) -> Reservation:
-        return DummyReservationBuilder(datetime.datetime.now()).build()
+        return DummyReservationBuilder().build()
 
     def test_予約をキャンセルができること(self, reservation: Reservation):
         expected = dataclasses.replace(reservation, reservation_status=ReservationStatus.Canceled)

--- a/tests/usecase/reservation/in_memory/test_in_memory_change_meeting_room_usecase.py
+++ b/tests/usecase/reservation/in_memory/test_in_memory_change_meeting_room_usecase.py
@@ -1,24 +1,20 @@
 import dataclasses
+import datetime
 import uuid
 
-import freezegun
 import pytest
 
-from src.domain.employee.employee_id import EmployeeId
 from src.domain.meeting_room.meeting_room_id import MeetingRoomId
-from src.domain.reservation.number_of_participants import NumberOfParticipants
 from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_domain_service import ReservationDomainService
 from src.domain.reservation.reservation_id import ReservationId
-from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
-from src.domain.reservation.使用日時 import 使用日時
 from src.infrastructure.reservation.in_memory_reservation_repository import InMemoryReservationRepository
 from src.usecase.reservation.change_meeting_room_usecase import ChangeMeetingRoomUseCase
 from src.usecase.reservation.errors import NotFoundReservationError
 from src.usecase.reservation.errors import その会議室はその時間帯では予約ができませんよエラー
+from tests.domain.reservation.dummy_reservation_builder import DummyReservationBuilder
 
 
-@freezegun.freeze_time('2020-4-1 10:00')
 class TestInMemoryChangeMeetingRoomUsecase:
     def setup(self):
         self.repository = InMemoryReservationRepository()
@@ -26,14 +22,8 @@ class TestInMemoryChangeMeetingRoomUsecase:
         self.usecase = ChangeMeetingRoomUseCase(self.repository, domain_service)
 
     @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
     def reservation(self) -> Reservation:
-        """不正でないReservationインスタンスを作成するだけのfixture"""
-        return Reservation(ReservationId(str(uuid.uuid4())),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'))
+        return DummyReservationBuilder(datetime.datetime.now()).build()
 
     def test_既存の予約を別の会議室に変更ができること(self, reservation):
         expected = dataclasses.replace(reservation, meeting_room_id=MeetingRoomId('B'))

--- a/tests/usecase/reservation/in_memory/test_in_memory_change_meeting_room_usecase.py
+++ b/tests/usecase/reservation/in_memory/test_in_memory_change_meeting_room_usecase.py
@@ -1,5 +1,4 @@
 import dataclasses
-import datetime
 import uuid
 
 import pytest
@@ -23,7 +22,7 @@ class TestInMemoryChangeMeetingRoomUsecase:
 
     @pytest.fixture
     def reservation(self) -> Reservation:
-        return DummyReservationBuilder(datetime.datetime.now()).build()
+        return DummyReservationBuilder().build()
 
     def test_既存の予約を別の会議室に変更ができること(self, reservation):
         expected = dataclasses.replace(reservation, meeting_room_id=MeetingRoomId('B'))

--- a/tests/usecase/reservation/in_memory/test_in_memory_change_time_range_usecase.py
+++ b/tests/usecase/reservation/in_memory/test_in_memory_change_time_range_usecase.py
@@ -1,5 +1,4 @@
 import dataclasses
-import datetime
 import uuid
 
 import freezegun
@@ -26,7 +25,7 @@ class TestInMemoryChangeTimeRangeUsecase:
     @pytest.fixture
     @freezegun.freeze_time('2020-4-1 10:00')
     def reservation(self) -> Reservation:
-        return DummyReservationBuilder(datetime.datetime.now()).build()
+        return DummyReservationBuilder().build()
 
     @freezegun.freeze_time('2020-4-1 10:00')
     def test_既存の予約を別の時間帯に変更ができること(self, reservation: Reservation):
@@ -63,7 +62,7 @@ class TestInMemoryChangeTimeRangeUsecase:
         @freezegun.freeze_time('2020-4-01 10:00')
         def reservation_20200402_1300_1400() -> Reservation:
             """テストのために、 '2020-4-10 10:00' 時点では本来不正である過去の予約時間帯を持つデータを作る関数"""
-            return DummyReservationBuilder(datetime.datetime.now()).build()
+            return DummyReservationBuilder().build()
 
         exist_reservation = reservation_20200402_1300_1400()
         self.repository.data[exist_reservation.id] = exist_reservation

--- a/tests/usecase/reservation/in_memory/test_in_memory_change_time_range_usecase.py
+++ b/tests/usecase/reservation/in_memory/test_in_memory_change_time_range_usecase.py
@@ -1,12 +1,10 @@
 import dataclasses
+import datetime
 import uuid
 
 import freezegun
 import pytest
 
-from src.domain.employee.employee_id import EmployeeId
-from src.domain.meeting_room.meeting_room_id import MeetingRoomId
-from src.domain.reservation.number_of_participants import NumberOfParticipants
 from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_domain_service import ReservationDomainService
 from src.domain.reservation.reservation_id import ReservationId
@@ -16,6 +14,7 @@ from src.infrastructure.reservation.in_memory_reservation_repository import InMe
 from src.usecase.reservation.change_time_range_usecase import ChangeTimeRangeUsecase
 from src.usecase.reservation.errors import NotFoundReservationError
 from src.usecase.reservation.errors import その会議室はその時間帯では予約ができませんよエラー
+from tests.domain.reservation.dummy_reservation_builder import DummyReservationBuilder
 
 
 class TestInMemoryChangeTimeRangeUsecase:
@@ -27,15 +26,10 @@ class TestInMemoryChangeTimeRangeUsecase:
     @pytest.fixture
     @freezegun.freeze_time('2020-4-1 10:00')
     def reservation(self) -> Reservation:
-        """不正でないReservationインスタンスを作成するだけのfixture"""
-        return Reservation(ReservationId(str(uuid.uuid4())),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'))
+        return DummyReservationBuilder(datetime.datetime.now()).build()
 
     @freezegun.freeze_time('2020-4-1 10:00')
-    def test_既存の予約を別の時間帯に変更ができること(self, reservation):
+    def test_既存の予約を別の時間帯に変更ができること(self, reservation: Reservation):
         new_time_range_to_reserve = TimeRangeToReserve(使用日時(2020, 4, 2, 15, 00), 使用日時(2020, 4, 2, 17, 00))
         expected = dataclasses.replace(reservation, time_range_to_reserve=new_time_range_to_reserve)
 
@@ -45,14 +39,14 @@ class TestInMemoryChangeTimeRangeUsecase:
         assert expected == self.repository.data[reservation.id]
 
     @freezegun.freeze_time('2020-4-1 10:00')
-    def test_存在しない予約に対する予約時間帯の変更依頼はダメだよ(self, reservation):
+    def test_存在しない予約に対する予約時間帯の変更依頼はダメだよ(self, reservation: Reservation):
         new_time_range_to_reserve = TimeRangeToReserve(使用日時(2020, 4, 2, 15, 00), 使用日時(2020, 4, 2, 17, 00))
 
         with pytest.raises(NotFoundReservationError):
             self.usecase.change_time_range(reservation.id, new_time_range_to_reserve)
 
     @freezegun.freeze_time('2020-4-1 10:00')
-    def test_予約時間帯変更後の予約が既存の予約とぶつかっていたらダメだよ(self, reservation):
+    def test_予約時間帯変更後の予約が既存の予約とぶつかっていたらダメだよ(self, reservation: Reservation):
         reservation2 = dataclasses.replace(reservation,
                                            id=ReservationId(str(uuid.uuid4())),
                                            time_range_to_reserve=TimeRangeToReserve(使用日時(2020, 4, 2, 15, 00),
@@ -65,15 +59,11 @@ class TestInMemoryChangeTimeRangeUsecase:
             self.usecase.change_time_range(reservation2.id, reservation.time_range_to_reserve)
 
     @freezegun.freeze_time('2020-4-10 10:00')
-    def test_予約時点では未来過ぎたが変更時点ではちゃんとした予約時間帯になっているから大丈夫(self, reservation):
+    def test_予約時点では未来過ぎたが変更時点ではちゃんとした予約時間帯になっているから大丈夫(self, reservation: Reservation):
         @freezegun.freeze_time('2020-4-01 10:00')
         def reservation_20200402_1300_1400() -> Reservation:
             """テストのために、 '2020-4-10 10:00' 時点では本来不正である過去の予約時間帯を持つデータを作る関数"""
-            return Reservation(ReservationId(str(uuid.uuid4())),
-                               TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                               NumberOfParticipants(4),
-                               MeetingRoomId('A'),
-                               EmployeeId('001'))
+            return DummyReservationBuilder(datetime.datetime.now()).build()
 
         exist_reservation = reservation_20200402_1300_1400()
         self.repository.data[exist_reservation.id] = exist_reservation

--- a/tests/usecase/reservation/in_memory/test_in_memory_find_available_reservation_usecase.py
+++ b/tests/usecase/reservation/in_memory/test_in_memory_find_available_reservation_usecase.py
@@ -1,5 +1,3 @@
-import datetime
-
 import freezegun
 import pytest
 
@@ -13,14 +11,14 @@ class TestInMemoryFindAvailableReservationsUsecase:
     @pytest.fixture
     @freezegun.freeze_time('2020-3-1 10:00')
     def past_reservation(self) -> Reservation:
-        return DummyReservationBuilder(datetime.datetime.now()).with_random_id().build()
+        return DummyReservationBuilder().with_random_id().build()
 
     @freezegun.freeze_time('2020-4-1 10:00')
     def test_find_available_reservations(self, past_reservation: Reservation):
         repository = InMemoryReservationRepository()
         usecase = FindAvailableReservationsUsecase(repository)
 
-        builder = DummyReservationBuilder(datetime.datetime.now())
+        builder = DummyReservationBuilder()
         available_reservation = builder.build()
         cancelled_reservation = builder.with_cancel().build()
 

--- a/tests/usecase/reservation/in_memory/test_in_memory_find_available_reservation_usecase.py
+++ b/tests/usecase/reservation/in_memory/test_in_memory_find_available_reservation_usecase.py
@@ -1,51 +1,31 @@
-import dataclasses
-import uuid
+import datetime
 
 import freezegun
 import pytest
 
-from src.domain.employee.employee_id import EmployeeId
-from src.domain.meeting_room.meeting_room_id import MeetingRoomId
-from src.domain.reservation.number_of_participants import NumberOfParticipants
 from src.domain.reservation.reservation import Reservation
-from src.domain.reservation.reservation_id import ReservationId
-from src.domain.reservation.reservation_status import ReservationStatus
-from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
-from src.domain.reservation.使用日時 import 使用日時
 from src.infrastructure.reservation.in_memory_reservation_repository import InMemoryReservationRepository
 from src.usecase.reservation.find_avalible_reservation_usecase import FindAvailableReservationsUsecase
+from tests.domain.reservation.dummy_reservation_builder import DummyReservationBuilder
 
 
 class TestInMemoryFindAvailableReservationsUsecase:
     @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def reservation_0402(self) -> Reservation:
-        return Reservation(ReservationId(str(uuid.uuid4())),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'))
-
-    @pytest.fixture
     @freezegun.freeze_time('2020-3-1 10:00')
-    def reservation_0301(self) -> Reservation:
-        return Reservation(ReservationId(str(uuid.uuid4())),
-                           TimeRangeToReserve(使用日時(2020, 3, 2, 13, 00), 使用日時(2020, 3, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'))
+    def past_reservation(self) -> Reservation:
+        return DummyReservationBuilder(datetime.datetime.now()).with_random_id().build()
 
     @freezegun.freeze_time('2020-4-1 10:00')
-    def test_find_available_reservations(self, reservation_0402: Reservation, reservation_0301: Reservation):
+    def test_find_available_reservations(self, past_reservation: Reservation):
         repository = InMemoryReservationRepository()
         usecase = FindAvailableReservationsUsecase(repository)
 
-        cancelled_reservation = dataclasses.replace(reservation_0402,
-                                                    id=ReservationId(str(uuid.uuid4())),
-                                                    reservation_status=ReservationStatus.Canceled)
+        builder = DummyReservationBuilder(datetime.datetime.now())
+        available_reservation = builder.build()
+        cancelled_reservation = builder.with_cancel().build()
 
-        repository.data[reservation_0402.id] = reservation_0402
-        repository.data[reservation_0301.id] = reservation_0301
+        repository.data[available_reservation.id] = available_reservation
         repository.data[cancelled_reservation.id] = cancelled_reservation
+        repository.data[past_reservation.id] = past_reservation
 
-        assert usecase.find_available_reservations() == [reservation_0402]
+        assert usecase.find_available_reservations() == [available_reservation]

--- a/tests/usecase/reservation/in_memory/test_in_memory_find_reservation_use_case.py
+++ b/tests/usecase/reservation/in_memory/test_in_memory_find_reservation_use_case.py
@@ -1,5 +1,4 @@
 import dataclasses
-import datetime
 from dataclasses import dataclass
 
 import pytest
@@ -32,7 +31,7 @@ class TestInMemoryFindReservationsUsecase:
 
     @pytest.fixture
     def reservation(self) -> Reservation:
-        return DummyReservationBuilder(datetime.datetime.now()).build()
+        return DummyReservationBuilder().build()
 
     def test_指定IDのReservationが1件だけ取得できる(self, reservation: Reservation):
         self.repository.data[reservation.id] = reservation

--- a/tests/usecase/reservation/in_memory/test_in_memory_find_reservation_use_case.py
+++ b/tests/usecase/reservation/in_memory/test_in_memory_find_reservation_use_case.py
@@ -1,19 +1,15 @@
 import dataclasses
-import uuid
+import datetime
 from dataclasses import dataclass
 
-import freezegun
 import pytest
 
-from src.domain.employee.employee_id import EmployeeId
 from src.domain.meeting_room.meeting_room_id import MeetingRoomId
-from src.domain.reservation.number_of_participants import NumberOfParticipants
 from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_id import ReservationId
-from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
-from src.domain.reservation.使用日時 import 使用日時
 from src.infrastructure.reservation.in_memory_reservation_repository import InMemoryReservationRepository
 from src.usecase.reservation.errors import NotFoundReservationError
+from tests.domain.reservation.dummy_reservation_builder import DummyReservationBuilder
 
 
 @dataclass
@@ -35,14 +31,8 @@ class TestInMemoryFindReservationsUsecase:
         self.usecase = FindReservationsUsecase(self.repository)
 
     @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
     def reservation(self) -> Reservation:
-        """不正でないReservationインスタンスを作成するだけのfixture"""
-        return Reservation(ReservationId(str(uuid.uuid4())),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'))
+        return DummyReservationBuilder(datetime.datetime.now()).build()
 
     def test_指定IDのReservationが1件だけ取得できる(self, reservation: Reservation):
         self.repository.data[reservation.id] = reservation

--- a/tests/usecase/reservation/in_memory/test_in_memory_reserve_meeting_room_usecase.py
+++ b/tests/usecase/reservation/in_memory/test_in_memory_reserve_meeting_room_usecase.py
@@ -1,5 +1,4 @@
 import dataclasses
-import datetime
 import uuid
 
 import pytest
@@ -23,7 +22,7 @@ class TestInMemoryReserveMeetingRoomUsecase:
 
     @pytest.fixture
     def reservation(self) -> Reservation:
-        return DummyReservationBuilder(datetime.datetime.now()).build()
+        return DummyReservationBuilder().build()
 
     def test_会議室を予約する_正常系(self, reservation):
         self.usecase.reserve_meeting_room(reservation)

--- a/tests/usecase/reservation/in_memory/test_in_memory_reserve_meeting_room_usecase.py
+++ b/tests/usecase/reservation/in_memory/test_in_memory_reserve_meeting_room_usecase.py
@@ -1,21 +1,18 @@
 import dataclasses
+import datetime
 import uuid
 
-import freezegun
 import pytest
 
-from src.domain.employee.employee_id import EmployeeId
-from src.domain.meeting_room.meeting_room_id import MeetingRoomId
 from src.domain.reservation.number_of_participants import NumberOfParticipants
 from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_domain_service import ReservationDomainService
 from src.domain.reservation.reservation_id import ReservationId
 from src.domain.reservation.reservation_status import ReservationStatus
-from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
-from src.domain.reservation.使用日時 import 使用日時
 from src.infrastructure.reservation.in_memory_reservation_repository import InMemoryReservationRepository
 from src.usecase.reservation.errors import その会議室はその時間帯では予約ができませんよエラー
 from src.usecase.reservation.reserve_meeting_room_usecase import ReserveMeetingRoomUsecase
+from tests.domain.reservation.dummy_reservation_builder import DummyReservationBuilder
 
 
 class TestInMemoryReserveMeetingRoomUsecase:
@@ -25,22 +22,14 @@ class TestInMemoryReserveMeetingRoomUsecase:
         self.usecase = ReserveMeetingRoomUsecase(self.reservation_repository, domain_service)
 
     @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
     def reservation(self) -> Reservation:
-        """不正でないReservationインスタンスを作成するだけのfixture"""
-        return Reservation(ReservationId(str(uuid.uuid4())),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'))
+        return DummyReservationBuilder(datetime.datetime.now()).build()
 
-    @freezegun.freeze_time('2020-4-1 10:00')
     def test_会議室を予約する_正常系(self, reservation):
         self.usecase.reserve_meeting_room(reservation)
 
         assert reservation == self.reservation_repository.data[reservation.id]
 
-    @freezegun.freeze_time('2020-4-1 10:00')
     def test_会議室を予約する_異常系_会議室と予約時間帯が完全に被っている(self, reservation):
         # このテストクラスでは、予約時間帯が完全一致のテストケースしか要していないが、
         # 他のパターンは予約時間帯のテストケースでクリアしているので、特に不安はない
@@ -54,7 +43,6 @@ class TestInMemoryReserveMeetingRoomUsecase:
         with pytest.raises(その会議室はその時間帯では予約ができませんよエラー):
             self.usecase.reserve_meeting_room(new_reservation)
 
-    @freezegun.freeze_time('2020-4-1 10:00')
     def test_会議室を予約する_正常系_会議室と時間帯的には予約できないけどキャンセル済みだから予約できるんだなあ(self, reservation):
         exist_canceled_reservation = dataclasses.replace(reservation, reservation_status=ReservationStatus.Canceled)
 

--- a/tests/usecase/reservation/orator/test_orator_cancel_meeting_room_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_cancel_meeting_room_usecase.py
@@ -1,5 +1,4 @@
 import dataclasses
-import datetime
 
 from orator import DatabaseManager, Model
 
@@ -23,7 +22,7 @@ class TestOratorCancelMeetingRoomUsecase:
         self.usecase = CancelMeetingRoomUsecase(self.repository)
 
     def test_指定した予約のみがキャンセルとなること(self):
-        builder = DummyReservationBuilder(datetime.datetime.now())
+        builder = DummyReservationBuilder()
         reservation_0402_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()
         reservation_0402_B = builder.with_meeting_room_id(MeetingRoomId('B')).build()
         reservation_0402_C = builder.with_meeting_room_id(MeetingRoomId('C')).build()

--- a/tests/usecase/reservation/orator/test_orator_cancel_meeting_room_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_cancel_meeting_room_usecase.py
@@ -1,7 +1,6 @@
 import dataclasses
 import datetime
 
-import freezegun
 from orator import DatabaseManager, Model
 
 from src.domain.meeting_room.meeting_room_id import MeetingRoomId
@@ -23,7 +22,6 @@ class TestOratorCancelMeetingRoomUsecase:
         self.repository = OratorReservationRepository()
         self.usecase = CancelMeetingRoomUsecase(self.repository)
 
-    @freezegun.freeze_time('2020-4-1 10:00')
     def test_指定した予約のみがキャンセルとなること(self):
         builder = DummyReservationBuilder(datetime.datetime.now())
         reservation_0402_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()

--- a/tests/usecase/reservation/orator/test_orator_cancel_meeting_room_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_cancel_meeting_room_usecase.py
@@ -23,22 +23,22 @@ class TestOratorCancelMeetingRoomUsecase:
 
     def test_指定した予約のみがキャンセルとなること(self):
         builder = DummyReservationBuilder()
-        reservation_0402_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()
-        reservation_0402_B = builder.with_meeting_room_id(MeetingRoomId('B')).build()
-        reservation_0402_C = builder.with_meeting_room_id(MeetingRoomId('C')).build()
+        reservation_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()
+        reservation_B = builder.with_meeting_room_id(MeetingRoomId('B')).build()
+        reservation_C = builder.with_meeting_room_id(MeetingRoomId('C')).build()
 
-        self.repository.reserve_new_meeting_room(reservation_0402_A)
-        self.repository.reserve_new_meeting_room(reservation_0402_B)
-        self.repository.reserve_new_meeting_room(reservation_0402_C)
+        self.repository.reserve_new_meeting_room(reservation_A)
+        self.repository.reserve_new_meeting_room(reservation_B)
+        self.repository.reserve_new_meeting_room(reservation_C)
 
-        self.usecase.cancel_meeting_room(reservation_0402_B.id)
+        self.usecase.cancel_meeting_room(reservation_B.id)
 
-        expected = [reservation_0402_A,
-                    dataclasses.replace(reservation_0402_B, reservation_status=ReservationStatus.Canceled),
-                    reservation_0402_C]
+        expected = [reservation_A,
+                    dataclasses.replace(reservation_B, reservation_status=ReservationStatus.Canceled),
+                    reservation_C]
 
-        actual = [self.repository.find_by_id(reservation_0402_A.id),
-                  self.repository.find_by_id(reservation_0402_B.id),
-                  self.repository.find_by_id(reservation_0402_C.id)]
+        actual = [self.repository.find_by_id(reservation_A.id),
+                  self.repository.find_by_id(reservation_B.id),
+                  self.repository.find_by_id(reservation_C.id)]
 
         assert actual == expected

--- a/tests/usecase/reservation/orator/test_orator_cancel_meeting_room_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_cancel_meeting_room_usecase.py
@@ -1,19 +1,14 @@
 import dataclasses
+import datetime
 
 import freezegun
-import pytest
 from orator import DatabaseManager, Model
 
-from src.domain.employee.employee_id import EmployeeId
 from src.domain.meeting_room.meeting_room_id import MeetingRoomId
-from src.domain.reservation.number_of_participants import NumberOfParticipants
-from src.domain.reservation.reservation import Reservation
-from src.domain.reservation.reservation_id import ReservationId
 from src.domain.reservation.reservation_status import ReservationStatus
-from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
-from src.domain.reservation.使用日時 import 使用日時
 from src.infrastructure.reservation.orator.orator_reservation_repository import OratorReservationRepository
 from src.usecase.reservation.cancel_meeting_room_usecase import CancelMeetingRoomUsecase
+from tests.domain.reservation.dummy_reservation_builder import DummyReservationBuilder
 from tests.usecase.reservation.orator.migrate_in_memory import TEST_DB_CONFIG, migrate_in_memory
 
 
@@ -28,35 +23,13 @@ class TestOratorCancelMeetingRoomUsecase:
         self.repository = OratorReservationRepository()
         self.usecase = CancelMeetingRoomUsecase(self.repository)
 
-    @pytest.fixture
     @freezegun.freeze_time('2020-4-1 10:00')
-    def reservation_0402_A(self) -> Reservation:
-        return Reservation(ReservationId('0402A'),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'))
+    def test_指定した予約のみがキャンセルとなること(self):
+        builder = DummyReservationBuilder(datetime.datetime.now())
+        reservation_0402_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()
+        reservation_0402_B = builder.with_meeting_room_id(MeetingRoomId('B')).build()
+        reservation_0402_C = builder.with_meeting_room_id(MeetingRoomId('C')).build()
 
-    @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def reservation_0402_B(self) -> Reservation:
-        return Reservation(ReservationId('0402B'),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('B'),
-                           EmployeeId('001'))
-
-    @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def reservation_0402_C(self) -> Reservation:
-        return Reservation(ReservationId('0402C'),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('C'),
-                           EmployeeId('001'))
-
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def test_指定した予約のみがキャンセルとなること(self, reservation_0402_A, reservation_0402_B, reservation_0402_C):
         self.repository.reserve_new_meeting_room(reservation_0402_A)
         self.repository.reserve_new_meeting_room(reservation_0402_B)
         self.repository.reserve_new_meeting_room(reservation_0402_C)

--- a/tests/usecase/reservation/orator/test_orator_change_meeting_room_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_change_meeting_room_usecase.py
@@ -1,7 +1,6 @@
 import dataclasses
 import datetime
 
-import freezegun
 from orator import DatabaseManager, Model
 
 from src.domain.meeting_room.meeting_room_id import MeetingRoomId
@@ -23,7 +22,6 @@ class TestOratorChangeMeetingRoomUsecase:
         domain_service = ReservationDomainService(self.repository)
         self.usecase = ChangeMeetingRoomUseCase(self.repository, domain_service)
 
-    @freezegun.freeze_time('2020-4-1 10:00')
     def test_指定した予約の会議室を変更できること(self):
         builder = DummyReservationBuilder(datetime.datetime.now())
         reservation_0402_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()

--- a/tests/usecase/reservation/orator/test_orator_change_meeting_room_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_change_meeting_room_usecase.py
@@ -1,19 +1,14 @@
 import dataclasses
+import datetime
 
 import freezegun
-import pytest
 from orator import DatabaseManager, Model
 
-from src.domain.employee.employee_id import EmployeeId
 from src.domain.meeting_room.meeting_room_id import MeetingRoomId
-from src.domain.reservation.number_of_participants import NumberOfParticipants
-from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_domain_service import ReservationDomainService
-from src.domain.reservation.reservation_id import ReservationId
-from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
-from src.domain.reservation.使用日時 import 使用日時
 from src.infrastructure.reservation.orator.orator_reservation_repository import OratorReservationRepository
 from src.usecase.reservation.change_meeting_room_usecase import ChangeMeetingRoomUseCase
+from tests.domain.reservation.dummy_reservation_builder import DummyReservationBuilder
 from tests.usecase.reservation.orator.migrate_in_memory import TEST_DB_CONFIG, migrate_in_memory
 
 
@@ -28,35 +23,13 @@ class TestOratorChangeMeetingRoomUsecase:
         domain_service = ReservationDomainService(self.repository)
         self.usecase = ChangeMeetingRoomUseCase(self.repository, domain_service)
 
-    @pytest.fixture
     @freezegun.freeze_time('2020-4-1 10:00')
-    def reservation_0402_A(self) -> Reservation:
-        return Reservation(ReservationId('0402A'),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'))
+    def test_指定した予約の会議室を変更できること(self):
+        builder = DummyReservationBuilder(datetime.datetime.now())
+        reservation_0402_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()
+        reservation_0402_B = builder.with_meeting_room_id(MeetingRoomId('B')).build()
+        reservation_0402_C = builder.with_meeting_room_id(MeetingRoomId('C')).build()
 
-    @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def reservation_0402_B(self) -> Reservation:
-        return Reservation(ReservationId('0402B'),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('B'),
-                           EmployeeId('001'))
-
-    @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def reservation_0402_C(self) -> Reservation:
-        return Reservation(ReservationId('0402C'),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('C'),
-                           EmployeeId('001'))
-
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def test_指定した予約の会議室を変更できること(self, reservation_0402_A, reservation_0402_B, reservation_0402_C):
         self.repository.reserve_new_meeting_room(reservation_0402_A)
         self.repository.reserve_new_meeting_room(reservation_0402_B)
         self.repository.reserve_new_meeting_room(reservation_0402_C)

--- a/tests/usecase/reservation/orator/test_orator_change_meeting_room_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_change_meeting_room_usecase.py
@@ -1,5 +1,4 @@
 import dataclasses
-import datetime
 
 from orator import DatabaseManager, Model
 
@@ -23,7 +22,7 @@ class TestOratorChangeMeetingRoomUsecase:
         self.usecase = ChangeMeetingRoomUseCase(self.repository, domain_service)
 
     def test_指定した予約の会議室を変更できること(self):
-        builder = DummyReservationBuilder(datetime.datetime.now())
+        builder = DummyReservationBuilder()
         reservation_0402_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()
         reservation_0402_B = builder.with_meeting_room_id(MeetingRoomId('B')).build()
         reservation_0402_C = builder.with_meeting_room_id(MeetingRoomId('C')).build()

--- a/tests/usecase/reservation/orator/test_orator_change_meeting_room_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_change_meeting_room_usecase.py
@@ -23,23 +23,23 @@ class TestOratorChangeMeetingRoomUsecase:
 
     def test_指定した予約の会議室を変更できること(self):
         builder = DummyReservationBuilder()
-        reservation_0402_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()
-        reservation_0402_B = builder.with_meeting_room_id(MeetingRoomId('B')).build()
-        reservation_0402_C = builder.with_meeting_room_id(MeetingRoomId('C')).build()
+        reservation_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()
+        reservation_B = builder.with_meeting_room_id(MeetingRoomId('B')).build()
+        reservation_C = builder.with_meeting_room_id(MeetingRoomId('C')).build()
 
-        self.repository.reserve_new_meeting_room(reservation_0402_A)
-        self.repository.reserve_new_meeting_room(reservation_0402_B)
-        self.repository.reserve_new_meeting_room(reservation_0402_C)
+        self.repository.reserve_new_meeting_room(reservation_A)
+        self.repository.reserve_new_meeting_room(reservation_B)
+        self.repository.reserve_new_meeting_room(reservation_C)
 
         meeting_room_id_Z = MeetingRoomId('Z')
-        self.usecase.change_meeting_room(reservation_0402_B.id, meeting_room_id_Z)
+        self.usecase.change_meeting_room(reservation_B.id, meeting_room_id_Z)
 
-        expected = [reservation_0402_A,
-                    dataclasses.replace(reservation_0402_B, meeting_room_id=meeting_room_id_Z),
-                    reservation_0402_C]
+        expected = [reservation_A,
+                    dataclasses.replace(reservation_B, meeting_room_id=meeting_room_id_Z),
+                    reservation_C]
 
-        actual = [self.repository.find_by_id(reservation_0402_A.id),
-                  self.repository.find_by_id(reservation_0402_B.id),
-                  self.repository.find_by_id(reservation_0402_C.id)]
+        actual = [self.repository.find_by_id(reservation_A.id),
+                  self.repository.find_by_id(reservation_B.id),
+                  self.repository.find_by_id(reservation_C.id)]
 
         assert actual == expected

--- a/tests/usecase/reservation/orator/test_orator_change_time_range_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_change_time_range_usecase.py
@@ -27,23 +27,23 @@ class TestOratorChangeTimeRangeUsecase:
     @freezegun.freeze_time('2020-4-1 10:00')
     def test_指定した予約の予約時間帯を変更できること(self):
         builder = DummyReservationBuilder()
-        reservation_0402_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()
-        reservation_0402_B = builder.with_meeting_room_id(MeetingRoomId('B')).build()
-        reservation_0402_C = builder.with_meeting_room_id(MeetingRoomId('C')).build()
+        reservation_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()
+        reservation_B = builder.with_meeting_room_id(MeetingRoomId('B')).build()
+        reservation_C = builder.with_meeting_room_id(MeetingRoomId('C')).build()
 
-        self.repository.reserve_new_meeting_room(reservation_0402_A)
-        self.repository.reserve_new_meeting_room(reservation_0402_B)
-        self.repository.reserve_new_meeting_room(reservation_0402_C)
+        self.repository.reserve_new_meeting_room(reservation_A)
+        self.repository.reserve_new_meeting_room(reservation_B)
+        self.repository.reserve_new_meeting_room(reservation_C)
 
         new_time_range_to_reserve = TimeRangeToReserve(使用日時(2020, 4, 9, 15, 00), 使用日時(2020, 4, 9, 17, 00))
-        self.usecase.change_time_range(reservation_0402_B.id, new_time_range_to_reserve)
+        self.usecase.change_time_range(reservation_B.id, new_time_range_to_reserve)
 
-        expected = [reservation_0402_A,
-                    dataclasses.replace(reservation_0402_B, time_range_to_reserve=new_time_range_to_reserve),
-                    reservation_0402_C]
+        expected = [reservation_A,
+                    dataclasses.replace(reservation_B, time_range_to_reserve=new_time_range_to_reserve),
+                    reservation_C]
 
-        actual = [self.repository.find_by_id(reservation_0402_A.id),
-                  self.repository.find_by_id(reservation_0402_B.id),
-                  self.repository.find_by_id(reservation_0402_C.id)]
+        actual = [self.repository.find_by_id(reservation_A.id),
+                  self.repository.find_by_id(reservation_B.id),
+                  self.repository.find_by_id(reservation_C.id)]
 
         assert actual == expected

--- a/tests/usecase/reservation/orator/test_orator_change_time_range_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_change_time_range_usecase.py
@@ -1,5 +1,4 @@
 import dataclasses
-import datetime
 
 import freezegun
 from orator import DatabaseManager, Model
@@ -27,7 +26,7 @@ class TestOratorChangeTimeRangeUsecase:
 
     @freezegun.freeze_time('2020-4-1 10:00')
     def test_指定した予約の予約時間帯を変更できること(self):
-        builder = DummyReservationBuilder(datetime.datetime.now())
+        builder = DummyReservationBuilder()
         reservation_0402_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()
         reservation_0402_B = builder.with_meeting_room_id(MeetingRoomId('B')).build()
         reservation_0402_C = builder.with_meeting_room_id(MeetingRoomId('C')).build()

--- a/tests/usecase/reservation/orator/test_orator_change_time_range_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_change_time_range_usecase.py
@@ -1,19 +1,16 @@
 import dataclasses
+import datetime
 
 import freezegun
-import pytest
 from orator import DatabaseManager, Model
 
-from src.domain.employee.employee_id import EmployeeId
 from src.domain.meeting_room.meeting_room_id import MeetingRoomId
-from src.domain.reservation.number_of_participants import NumberOfParticipants
-from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_domain_service import ReservationDomainService
-from src.domain.reservation.reservation_id import ReservationId
 from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
 from src.domain.reservation.使用日時 import 使用日時
 from src.infrastructure.reservation.orator.orator_reservation_repository import OratorReservationRepository
 from src.usecase.reservation.change_time_range_usecase import ChangeTimeRangeUsecase
+from tests.domain.reservation.dummy_reservation_builder import DummyReservationBuilder
 from tests.usecase.reservation.orator.migrate_in_memory import migrate_in_memory, TEST_DB_CONFIG
 
 
@@ -28,35 +25,13 @@ class TestOratorChangeTimeRangeUsecase:
         domain_service = ReservationDomainService(self.repository)
         self.usecase = ChangeTimeRangeUsecase(self.repository, domain_service)
 
-    @pytest.fixture
     @freezegun.freeze_time('2020-4-1 10:00')
-    def reservation_0402_A(self) -> Reservation:
-        return Reservation(ReservationId('0402A'),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'))
+    def test_指定した予約の予約時間帯を変更できること(self):
+        builder = DummyReservationBuilder(datetime.datetime.now())
+        reservation_0402_A = builder.with_meeting_room_id(MeetingRoomId('A')).build()
+        reservation_0402_B = builder.with_meeting_room_id(MeetingRoomId('B')).build()
+        reservation_0402_C = builder.with_meeting_room_id(MeetingRoomId('C')).build()
 
-    @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def reservation_0402_B(self) -> Reservation:
-        return Reservation(ReservationId('0402B'),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('B'),
-                           EmployeeId('001'))
-
-    @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def reservation_0402_C(self) -> Reservation:
-        return Reservation(ReservationId('0402C'),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('C'),
-                           EmployeeId('001'))
-
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def test_指定した予約の予約時間帯を変更できること(self, reservation_0402_A, reservation_0402_B, reservation_0402_C):
         self.repository.reserve_new_meeting_room(reservation_0402_A)
         self.repository.reserve_new_meeting_room(reservation_0402_B)
         self.repository.reserve_new_meeting_room(reservation_0402_C)

--- a/tests/usecase/reservation/orator/test_orator_find_available_reservation_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_find_available_reservation_usecase.py
@@ -1,21 +1,14 @@
-import dataclasses
-import uuid
+import datetime
 
 import freezegun
 import pytest
 from orator import DatabaseManager, Model
 
-from src.domain.employee.employee_id import EmployeeId
-from src.domain.meeting_room.meeting_room_id import MeetingRoomId
-from src.domain.reservation.number_of_participants import NumberOfParticipants
 from src.domain.reservation.reservation import Reservation
-from src.domain.reservation.reservation_id import ReservationId
-from src.domain.reservation.reservation_status import ReservationStatus
-from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
-from src.domain.reservation.使用日時 import 使用日時
 from src.infrastructure.reservation.orator.orator_reservation_model import OratorReservationModel
 from src.infrastructure.reservation.orator.orator_reservation_repository import OratorReservationRepository
 from src.usecase.reservation.find_avalible_reservation_usecase import FindAvailableReservationsUsecase
+from tests.domain.reservation.dummy_reservation_builder import DummyReservationBuilder
 from tests.usecase.reservation.orator.migrate_in_memory import TEST_DB_CONFIG, migrate_in_memory
 
 
@@ -28,34 +21,21 @@ class TestOratorFindAvailableReservationsUsecase:
         migrate_in_memory(database_manager)
 
     @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def reservation_0402(self) -> Reservation:
-        return Reservation(ReservationId(str(uuid.uuid4())),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'))
-
-    @pytest.fixture
     @freezegun.freeze_time('2020-3-1 10:00')
-    def reservation_0301(self) -> Reservation:
-        return Reservation(ReservationId(str(uuid.uuid4())),
-                           TimeRangeToReserve(使用日時(2020, 3, 2, 13, 00), 使用日時(2020, 3, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'))
+    def past_reservation(self) -> Reservation:
+        return DummyReservationBuilder(datetime.datetime.now()).with_random_id().build()
 
     @freezegun.freeze_time('2020-4-1 10:00')
-    def test_find_available_reservations(self, reservation_0402: Reservation, reservation_0301: Reservation):
+    def test_find_available_reservations(self, past_reservation: Reservation):
         repository = OratorReservationRepository()
         usecase = FindAvailableReservationsUsecase(repository)
 
-        cancelled_reservation = dataclasses.replace(reservation_0402,
-                                                    id=ReservationId(str(uuid.uuid4())),
-                                                    reservation_status=ReservationStatus.Canceled)
+        builder = DummyReservationBuilder(datetime.datetime.now())
+        available_reservation = builder.build()
+        cancelled_reservation = builder.with_cancel().build()
 
-        OratorReservationModel.to_orator_model(reservation_0301).save()
-        OratorReservationModel.to_orator_model(reservation_0402).save()
+        OratorReservationModel.to_orator_model(past_reservation).save()
+        OratorReservationModel.to_orator_model(available_reservation).save()
         OratorReservationModel.to_orator_model(cancelled_reservation).save()
 
-        assert usecase.find_available_reservations() == [reservation_0402]
+        assert usecase.find_available_reservations() == [available_reservation]

--- a/tests/usecase/reservation/orator/test_orator_find_available_reservation_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_find_available_reservation_usecase.py
@@ -1,5 +1,3 @@
-import datetime
-
 import freezegun
 import pytest
 from orator import DatabaseManager, Model
@@ -23,14 +21,14 @@ class TestOratorFindAvailableReservationsUsecase:
     @pytest.fixture
     @freezegun.freeze_time('2020-3-1 10:00')
     def past_reservation(self) -> Reservation:
-        return DummyReservationBuilder(datetime.datetime.now()).with_random_id().build()
+        return DummyReservationBuilder().with_random_id().build()
 
     @freezegun.freeze_time('2020-4-1 10:00')
     def test_find_available_reservations(self, past_reservation: Reservation):
         repository = OratorReservationRepository()
         usecase = FindAvailableReservationsUsecase(repository)
 
-        builder = DummyReservationBuilder(datetime.datetime.now())
+        builder = DummyReservationBuilder()
         available_reservation = builder.build()
         cancelled_reservation = builder.with_cancel().build()
 

--- a/tests/usecase/reservation/orator/test_orator_reserve_meeting_room_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_reserve_meeting_room_usecase.py
@@ -1,5 +1,3 @@
-import datetime
-
 from orator import DatabaseManager, Model
 
 from src.domain.reservation.reservation_domain_service import ReservationDomainService
@@ -21,7 +19,7 @@ class TestOratorReserveMeetingRoomUsecase:
         self.usecase = ReserveMeetingRoomUsecase(self.repository, domain_service)
 
     def test_予約ができること_正常系(self):
-        reservation = DummyReservationBuilder(datetime.datetime.now()).build()
+        reservation = DummyReservationBuilder().build()
 
         self.usecase.reserve_meeting_room(reservation)
 

--- a/tests/usecase/reservation/orator/test_orator_reserve_meeting_room_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_reserve_meeting_room_usecase.py
@@ -1,10 +1,7 @@
 import datetime
 
-import freezegun
-import pytest
 from orator import DatabaseManager, Model
 
-from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_domain_service import ReservationDomainService
 from src.infrastructure.reservation.orator.orator_reservation_repository import OratorReservationRepository
 from src.usecase.reservation.reserve_meeting_room_usecase import ReserveMeetingRoomUsecase
@@ -23,13 +20,9 @@ class TestOratorReserveMeetingRoomUsecase:
         domain_service = ReservationDomainService(self.repository)
         self.usecase = ReserveMeetingRoomUsecase(self.repository, domain_service)
 
-    @pytest.fixture
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def reservation(self) -> Reservation:
-        return DummyReservationBuilder(datetime.datetime.now()).build()
+    def test_予約ができること_正常系(self):
+        reservation = DummyReservationBuilder(datetime.datetime.now()).build()
 
-    @freezegun.freeze_time('2020-4-1 10:00')
-    def test_予約ができること_正常系(self, reservation):
         self.usecase.reserve_meeting_room(reservation)
 
         assert reservation == self.repository.find_by_id(reservation.id)

--- a/tests/usecase/reservation/orator/test_orator_reserve_meeting_room_usecase.py
+++ b/tests/usecase/reservation/orator/test_orator_reserve_meeting_room_usecase.py
@@ -1,19 +1,14 @@
-import uuid
+import datetime
 
 import freezegun
 import pytest
 from orator import DatabaseManager, Model
 
-from src.domain.employee.employee_id import EmployeeId
-from src.domain.meeting_room.meeting_room_id import MeetingRoomId
-from src.domain.reservation.number_of_participants import NumberOfParticipants
 from src.domain.reservation.reservation import Reservation
 from src.domain.reservation.reservation_domain_service import ReservationDomainService
-from src.domain.reservation.reservation_id import ReservationId
-from src.domain.reservation.time_range_to_reserve import TimeRangeToReserve
-from src.domain.reservation.使用日時 import 使用日時
 from src.infrastructure.reservation.orator.orator_reservation_repository import OratorReservationRepository
 from src.usecase.reservation.reserve_meeting_room_usecase import ReserveMeetingRoomUsecase
+from tests.domain.reservation.dummy_reservation_builder import DummyReservationBuilder
 from tests.usecase.reservation.orator.migrate_in_memory import migrate_in_memory, TEST_DB_CONFIG
 
 
@@ -31,12 +26,7 @@ class TestOratorReserveMeetingRoomUsecase:
     @pytest.fixture
     @freezegun.freeze_time('2020-4-1 10:00')
     def reservation(self) -> Reservation:
-        """不正でないReservationインスタンスを作成するだけのfixture"""
-        return Reservation(ReservationId(str(uuid.uuid4())),
-                           TimeRangeToReserve(使用日時(2020, 4, 2, 13, 00), 使用日時(2020, 4, 2, 14, 00)),
-                           NumberOfParticipants(4),
-                           MeetingRoomId('A'),
-                           EmployeeId('001'))
+        return DummyReservationBuilder(datetime.datetime.now()).build()
 
     @freezegun.freeze_time('2020-4-1 10:00')
     def test_予約ができること_正常系(self, reservation):


### PR DESCRIPTION
## 解決したかったこと
- テスト用の `Reservation` を作るのコードの重複地獄

## 実際の変化
- コード行数は「全体で」50行ほど削減
    - テストデータの準備コードがめっちゃ多かったわけですね。
- `freezegun` を使うべきタイミングがより明確になった

## 使い方
DocString と テストコード を見てもらえれば使い方はわかると思います(逆にわからない部分があるなら、それはテストコードとして追加するのでぜひとも！)

- [tests/domain/reservation/dummy_reservation_builder.py](https://github.com/ModelingKai/meeting-room-python/blob/dummy_reservation_builder/tests/domain/reservation/dummy_reservation_builder.py)
- [tests/domain/reservation/test_dummy_reservation_builder.py](https://github.com/ModelingKai/meeting-room-python/blob/dummy_reservation_builder/tests/domain/reservation/test_dummy_reservation_builder.py)


## やらなかったこと
- `DummyReservationBuilder` が完全に正しい `Reservation` しか    
生成できなくすること
    - 労力がかかりすぎるから。テスト用のビルダークラスと割り切るほうとちょうどよいという判断です。
- 複数の`Reservation`を一挙に生成するメソッド
    - 同時に複数の `Reservation` を使うシーンは少ないから
- 状態をリセットするようなメソッドの実装
    - 生成するReservationは、まだまだバリエーションが少ないから。
    - 参照: 『実践テスト駆動開発』 p.272 よく似たオブジェクトの作成

## 参考
- 『実践テスト駆動開発』 p.270 第22章 テストデータビルダー